### PR TITLE
Incorporate video recording feature

### DIFF
--- a/tools/uzem/avr8.cpp
+++ b/tools/uzem/avr8.cpp
@@ -360,6 +360,7 @@ void avr8::write_io_x(u8 addr,u8 value)
 					// Temporarily disabled. The real solution would be moving this off to a seperate module!
 					// The dirty solution would be sending the data line by line to avconv.
 					// if (recordMovie && avconv_video) fwrite(surface->pixels, VIDEO_DISP_WIDTH*224*4, 1, avconv_video);
+		                        if (recordMovie && avconv_video) writeFrame(o_renderer, avconv_video);
 
 					SDL_Event event;
 					while (SDL_PollEvent(&event))
@@ -1896,34 +1897,10 @@ bool avr8::init_gui(renderIf* ren)
 	if (recordMovie){
 
 		if (avconv_video == NULL){
-			// Detect the pixel format that the GPU picked for optimal speed
-			char pix_fmt[] = "aaaa";
-			//
-			// TODO: Temporarily disabled. Needs to be rewritten, see at the line output.
-			// Maybe best would be sending line by line. Maybe the very best would be moving
-			// this entire thing to its own module.
-			//
-			//switch (surface->format->Rmask) {
-			//case 0xff000000: pix_fmt[3] = 'r'; break;
-			//case 0x00ff0000: pix_fmt[2] = 'r'; break;
-			//case 0x0000ff00: pix_fmt[1] = 'r'; break;
-			//case 0x000000ff: pix_fmt[0] = 'r'; break;
-			//}
-			//switch (surface->format->Gmask) {
-			//case 0xff000000: pix_fmt[3] = 'g'; break;
-			//case 0x00ff0000: pix_fmt[2] = 'g'; break;
-			//case 0x0000ff00: pix_fmt[1] = 'g'; break;
-			//case 0x000000ff: pix_fmt[0] = 'g'; break;
-			//}
-			//switch (surface->format->Bmask) {
-			//case 0xff000000: pix_fmt[3] = 'b'; break;
-			//case 0x00ff0000: pix_fmt[2] = 'b'; break;
-			//case 0x0000ff00: pix_fmt[1] = 'b'; break;
-			//case 0x000000ff: pix_fmt[0] = 'b'; break;
-			//}
-			printf("Pixel Format = %s\n", pix_fmt);
 			char avconv_video_cmd[1024] = {0};
-			snprintf(avconv_video_cmd, sizeof(avconv_video_cmd) - 1, "ffmpeg -y -f rawvideo -s %ux224 -pix_fmt %s -r 59.94 -i - -vf scale=960:720 -sws_flags neighbor -an -b:v 1000k uzemtemp.mp4", 618U, pix_fmt);
+                        char pix_fmt[5] = {0};
+                        o_renderer->getPixelFormatString(pix_fmt);
+			snprintf(avconv_video_cmd, sizeof(avconv_video_cmd) - 1, "ffmpeg -y -f rawvideo -s %ux448 -pix_fmt %s -r 59.94 -i - -vf scale=960:720 -sws_flags bilinear -an -preset ultrafast -qp 0 uzemtemp.mp4", 618U, pix_fmt);
 			avconv_video = popen(avconv_video_cmd, "w");
 		}
 		if (avconv_video == NULL){

--- a/tools/uzem/renderif.h
+++ b/tools/uzem/renderif.h
@@ -203,6 +203,8 @@ public:
 	// RENDERIF_D_WIDTH in debug mode.
 	//
 	virtual void getLine(uint32* dest, auint lno) = 0;
+	virtual void* getFrame(void) = 0;
+	virtual void getPixelFormatString(char* pix_fmt) = 0;
 };
 
 

--- a/tools/uzem/rendersoft.cpp
+++ b/tools/uzem/rendersoft.cpp
@@ -336,3 +336,33 @@ void renderSoft::getLine(uint32* dest, auint lno)
 		rendersupp_convsurf(dest, o_wsurf, lno, 0U, DISPLAY_WIDTH);
 	}
 }
+
+void* renderSoft::getFrame(void)
+{
+	return o_wsurf->pixels;
+}
+
+void renderSoft::getPixelFormatString(char* pix_fmt)
+{
+	// Detect the pixel format that the GPU picked for optimal speed
+	strcpy(pix_fmt, "aaaa\0");
+
+	switch (o_wsurf->format->Rmask) {
+	case 0xff000000: pix_fmt[3] = 'r'; break;
+	case 0x00ff0000: pix_fmt[2] = 'r'; break;
+	case 0x0000ff00: pix_fmt[1] = 'r'; break;
+	case 0x000000ff: pix_fmt[0] = 'r'; break;
+	}
+	switch (o_wsurf->format->Gmask) {
+	case 0xff000000: pix_fmt[3] = 'g'; break;
+	case 0x00ff0000: pix_fmt[2] = 'g'; break;
+	case 0x0000ff00: pix_fmt[1] = 'g'; break;
+	case 0x000000ff: pix_fmt[0] = 'g'; break;
+	}
+	switch (o_wsurf->format->Bmask) {
+	case 0xff000000: pix_fmt[3] = 'b'; break;
+	case 0x00ff0000: pix_fmt[2] = 'b'; break;
+	case 0x0000ff00: pix_fmt[1] = 'b'; break;
+	case 0x000000ff: pix_fmt[0] = 'b'; break;
+	}
+}

--- a/tools/uzem/rendersoft.h
+++ b/tools/uzem/rendersoft.h
@@ -71,6 +71,12 @@ public:
 	// See renderif
 	void getLine(uint32* dest, auint lno);
 
+	// See renderIf
+	void* getFrame(void);
+
+	// See renderIf
+	void getPixelFormatString(char* pix_fmt);
+
 private:
 	void destroy();
 

--- a/tools/uzem/screenshot.cpp
+++ b/tools/uzem/screenshot.cpp
@@ -74,3 +74,8 @@ void screenShot(renderIf* ren)
 
 	SDL_FreeSurface(surf);
 }
+
+void writeFrame(renderIf* ren, FILE *fp)
+{
+	fwrite(ren->getFrame(), RENDERIF_N_WIDTH*RENDERIF_N_HEIGHT*4, 1, fp);
+}

--- a/tools/uzem/screenshot.h
+++ b/tools/uzem/screenshot.h
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #ifndef SCREENSHOT_H
 #define SCREENSHOT_H
 
+#include <stdio.h>
 #include "types.h"
 #include "renderif.h"
 
@@ -47,5 +48,6 @@ THE SOFTWARE.
 //
 void screenShot(renderIf* ren);
 
+void writeFrame(renderIf* ren, FILE *fp);
 
 #endif


### PR DESCRIPTION
I modified the renderer interface to add a function for getting the raw pixels from a renderer, and one to get the pixel format, and I added support to your software renderer, so video recording works again (with scanline effects!) without having to do any format conversions. I was careful and did not add any dependencies on SDL to the render interface.
